### PR TITLE
Recompiled linux executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ python app.py
 git clone https://github.com/juvenestech/minecraft-juvenes-launcher
 cd minecraft-juvenes-launcher
 pip install -r requirements.txt
-pip install -r pyinstaller
+pip install pyinstaller
 python -m eel app.py web --onefile --noconsole
 ```


### PR DESCRIPTION
The linux executable got updated to support non-chromium based browsers (e.g. firefox) and an error in README.md got fixed ("pip install -r pyinstaller" was wrong, since -r is used to make pip install modules from a specific file)